### PR TITLE
feat(extract): Fix Exception Thrown When DayZ Experimental Isn't Installed

### DIFF
--- a/KuruExtract/Commands/ExtractDayZCommand.cs
+++ b/KuruExtract/Commands/ExtractDayZCommand.cs
@@ -214,6 +214,11 @@ internal sealed class ExtractDayZCommand : Command<ExtractDayZCommand.Settings>
         {
             settings.Experimental = AnsiConsole.Confirm("Extract experimental", settings.Experimental);
             if (settings.Experimental) settings.InstallationPath = GamePath.Experimental;
+            
+            if (settings.InstallationPath is not null) return;
+
+            AnsiConsole.Markup("[red]Error:[/] DayZ Experimental does not seem to be installed.");
+            Environment.Exit(-1);
         }
     }
 


### PR DESCRIPTION
This shit was really annoying me.

Added error message when InstallationPath is null