### PR TITLE
Fix "Resource key not found" exception in non-English locales

### DIFF
--- a/KuruExtract/Commands/ExtractDayZCommand.cs
+++ b/KuruExtract/Commands/ExtractDayZCommand.cs
@@ -6,6 +6,7 @@ using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace KuruExtract.Commands;
@@ -173,10 +174,10 @@ internal sealed class ExtractDayZCommand : Command<ExtractDayZCommand.Settings>
 
         Console.SetCursorPosition(0, 0);
 
-        var time = stopWatch.Elapsed.Minutes > 1 ? 2 : 1;
+        var timePrecision = stopWatch.Elapsed.Minutes > 1 ? 2 : 1;
 
         AnsiConsole.MarkupLine($"Extracted [yellow]{settings.InstallationPath}[/] to [yellow]{settings.Destination}[/]");
-        AnsiConsole.MarkupLine($"Took [yellow]{stopWatch.Elapsed.Humanize(time)}[/] to complete the operation");
+        AnsiConsole.MarkupLine($"Took [yellow]{stopWatch.Elapsed.Humanize(timePrecision, CultureInfo.InvariantCulture)}[/] to complete the operation");
 
         if (!settings.Unattended)
         {


### PR DESCRIPTION
## Problem
 
Users with non-English locales encounter the following exception when DayZExtract reports elapsed time:

![KuruExtractBug](https://user-images.githubusercontent.com/48875452/206742707-743c7900-9d27-4e83-bda5-744e8b42cee8.png)

It's not a big deal, since the program's already finished extraction, but it's inconvenient. This pull request fixes the issue by passing English-based locale to `Humanize` method.

## Changes

- Explicitly pass `InvariantCulture` to `Humanize` method;
- Rename `time` to `timePrecision` for readability.